### PR TITLE
Improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# Chirp - ChirpStack LoraWan Integration
+# Chirp - ChirpStack to HomeAssistant MQTT Integration
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) (https://github.com/modrisb/pijups/releases)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 
-
-Chirp as [Home Assistant](https://home-assistant.io) integration component glues together HA MQTT and ChirpStack LoraWan server. LoraWan devices information is retrieved from ChirpStack gRPC api server and exposed to HA MQTT integration discovery service. Data transferred by/to LoraWan devices are retained on MQTT server to support HA/integration restart. Detailed configuration information needed for HA is stored as ChirpStack codec extension.
+Chirp as [Home Assistant](https://home-assistant.io) integration component glues together HA MQTT and ChirpStack LoRaWAN server. LoRaWAN devices information is retrieved from ChirpStack gRPC api server and exposed to HA MQTT integration discovery service. Data transferred by/to LoRaWAN devices are retained on MQTT server to support HA/integration restart. Detailed configuration information needed for HA is stored as ChirpStack codec extension.
 
 ## Sensors supported
 * Chirp does not limit devices by type/features, but is limited by codec extension that need to be prepared for each device separately.

--- a/custom_components/chirp/__init__.py
+++ b/custom_components/chirp/__init__.py
@@ -1,4 +1,4 @@
-"""The Chirpstack LoRaWan integration - setup."""
+"""The ChirpStack LoRaWAN Integration - setup."""
 from __future__ import annotations
 
 import logging

--- a/custom_components/chirp/config_flow.py
+++ b/custom_components/chirp/config_flow.py
@@ -1,4 +1,4 @@
-"""The ChirpStack LoRaWan integration - base configuration."""
+"""The ChirpStack LoRaWAN Integration - base configuration."""
 import hashlib
 import logging
 import time
@@ -31,6 +31,7 @@ from .const import (
     CONF_MQTT_PWD,
     CONF_MQTT_SERVER,
     CONF_MQTT_USER,
+    CONF_MQTT_CHIRPSTACK_PREFIX,
     CONF_OPTIONS_DEBUG_PAYLOAD,
     CONF_OPTIONS_RESTORE_AGE,
     CONF_OPTIONS_START_DELAY,
@@ -40,6 +41,7 @@ from .const import (
     DEFAULT_API_SERVER,
     DEFAULT_APPLICATION,
     DEFAULT_MQTT_DISC,
+    DEFAULT_MQTT_CHIRPSTACK_PREFIX,
     DEFAULT_MQTT_PORT,
     DEFAULT_MQTT_PWD,
     DEFAULT_MQTT_SERVER,
@@ -70,6 +72,7 @@ def generate_unique_id(configuration):
                 CONF_MQTT_SERVER,
                 CONF_MQTT_PORT,
                 CONF_MQTT_DISC,
+                CONF_MQTT_CHIRPSTACK_PREFIX,
             )
         ]
     )
@@ -78,7 +81,7 @@ def generate_unique_id(configuration):
 
 
 class ChirpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Chirpstack LoRaWan configuration flow."""
+    """ChirpStack LoRaWAN configuration flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
@@ -307,6 +310,12 @@ class ChirpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         if not user_input
                         else user_input[CONF_MQTT_DISC],
                     ): vol.All(str,vol.Length(min=1)),
+                    vol.Optional(
+                        CONF_MQTT_CHIRPSTACK_PREFIX,
+                        default=DEFAULT_MQTT_CHIRPSTACK_PREFIX
+                        if not user_input
+                        else user_input.get(CONF_MQTT_CHIRPSTACK_PREFIX, DEFAULT_MQTT_CHIRPSTACK_PREFIX),
+                    ): str,
                 }
             ),
             errors=errors,

--- a/custom_components/chirp/const.py
+++ b/custom_components/chirp/const.py
@@ -1,4 +1,4 @@
-"""The Chirpstack LoRaWan integration - constant definitions."""
+"""The ChirpStack LoRaWAN Integration - constant definitions."""
 DOMAIN = "chirp"
 GRPCLIENT = "grpclient"
 MQTTCLIENT = "mqttclient"
@@ -28,12 +28,14 @@ CONF_MQTT_PORT = "mqtt_port"
 CONF_MQTT_USER = "mqtt_user"
 CONF_MQTT_PWD = "mqtt_password"
 CONF_MQTT_DISC = "discovery_prefix"
+CONF_MQTT_CHIRPSTACK_PREFIX = "mqtt_chirpstack_prefix"
 
 DEFAULT_MQTT_SERVER = "localhost"
 DEFAULT_MQTT_PORT = 1883
 DEFAULT_MQTT_USER = ""
 DEFAULT_MQTT_PWD = ""
 DEFAULT_MQTT_DISC = "homeassistant"
+DEFAULT_MQTT_CHIRPSTACK_PREFIX = ""
 
 CHIRPSTACK_TENANT = "HA owned"
 CHIRPSTACK_APPLICATION = "HA integration"

--- a/custom_components/chirp/grpc.py
+++ b/custom_components/chirp/grpc.py
@@ -1,4 +1,4 @@
-"""The Chirpstack LoRaWan integration - grpc interface to ChirpStack server."""
+"""The ChirpStack LoRaWAN Integration - grpc interface to ChirpStack server."""
 from __future__ import annotations
 
 import json

--- a/custom_components/chirp/manifest.json
+++ b/custom_components/chirp/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "chirp",
-    "name": "Chirpstack LoRaWan integration",
+    "name": "ChirpStack LoRaWAN Integration",
     "documentation": "https://github.com/modrisb/chirp/",
     "issue_tracker": "https://github.com/modrisb/chirp/issues",
     "requirements": ["paho-mqtt==2.1.0", "chirpstack-api==4.6.0", "dukpy==0.5.0"],

--- a/custom_components/chirp/mqtt.py
+++ b/custom_components/chirp/mqtt.py
@@ -571,7 +571,7 @@ class ChirpToHA:
                 time_stamp = payload_struct.get("time_stamp")
                 _LOGGER.debug(f"Processing message with time stamp {time_stamp} for topic {message.topic} and payload {payload_struct}")
 
-                if subtopics[-1] == "config":
+                if subtopics[-1] == "config" and payload_struct.get("device", {}).get("via_device") is not None:
                     if (
                         "via_device" in payload_struct["device"]
                         and payload_struct["device"]["via_device"]

--- a/custom_components/chirp/sensor.py
+++ b/custom_components/chirp/sensor.py
@@ -1,4 +1,4 @@
-"""The Chirpstack LoRaWan integration - sensor implementation."""
+"""The ChirpStack LoRaWAN Integration - sensor implementation."""
 
 import logging
 

--- a/custom_components/chirp/translations/en.json
+++ b/custom_components/chirp/translations/en.json
@@ -12,20 +12,21 @@
         "step": {
             "configure_mqtt": {
                 "data": {
-                    "discovery_prefix": "HA MQTT discovery prefix",
+                    "discovery_prefix": "HomeAssistant MQTT discovery prefix",
+                    "mqtt_chirpstack_prefix": "ChirpStack MQTT prefix",
                     "mqtt_password": "MQTT user password",
                     "mqtt_port": "MQTT server port",
                     "mqtt_server": "MQTT server",
                     "mqtt_user": "MQTT user name"
                 },
-                "title": "Configure MQTT server used by ChirpStack and HA"
+                "title": "Configure MQTT server used by ChirpStack and HomeAssistant"
             },
             "device_sensors": {
                 "data": {
                     "device_sensors": "Sensor id:name;device_class;state_class;category;units_of_mesurement;conversion_rule[;...]",
                     "device_sensors:batteryLevel:Battery": "Sensor id:name;device_class;state_class;category;units_of_mesurement;conversion_rule[;...]"
                 },
-                "title": "Configure generic LoraWan sensors present on every device"
+                "title": "Configure generic LoRaWAN sensors present on every device"
             },
             "select_application": {
                 "data": {
@@ -37,22 +38,22 @@
                 "data": {
                     "tenant": "Select tenant"
                 },
-                "title": "Select Chirpstack tenant for application selection"
+                "title": "Select ChirpStack tenant for application selection"
             },
             "user": {
                 "data": {
-                    "api_connection_key": "Connection key",
-                    "chirpstack_api_server": "Chirpstack API server",
-                    "server_port": "Server port"
+                    "api_connection_key": "API token",
+                    "chirpstack_api_server": "ChirpStack API server",
+                    "server_port": "Server port (HTTP Only!)"
                 },
-                "title": "Configure Chirpstack API server"
+                "title": "Configure ChirpStack API server"
             }
         }
     },
     "entity": {
         "button": {
             "chirp_reload": {
-                "name": "Reload LoraWan devicesX"
+                "name": "Reload LoRaWAN devicesX"
             }
         },
         "sensor": {

--- a/tests/components/chirp/common.py
+++ b/tests/components/chirp/common.py
@@ -15,6 +15,7 @@ from homeassistant.components.chirp.const import (
     CONF_MQTT_PWD,
     CONF_MQTT_SERVER,
     CONF_MQTT_USER,
+    CONF_MQTT_CHIRPSTACK_PREFIX,
     CONF_OPTIONS_DEBUG_PAYLOAD,
     CONF_OPTIONS_RESTORE_AGE,
     CONF_OPTIONS_START_DELAY,
@@ -44,6 +45,7 @@ CONFIG_DATA = {
     CONF_MQTT_USER: "user",
     CONF_MQTT_PWD: "pwd",
     CONF_MQTT_DISC: "ha",
+    CONF_MQTT_CHIRPSTACK_PREFIX: "",
 }
 
 CONFIG_OPTIONS = {

--- a/tests/components/chirp/test_config_flow.py
+++ b/tests/components/chirp/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.components.chirp.const import (
     CONF_MQTT_PWD,
     CONF_MQTT_SERVER,
     CONF_MQTT_USER,
+    CONF_MQTT_CHIRPSTACK_PREFIX,
     CONF_OPTIONS_DEBUG_PAYLOAD,
     CONF_OPTIONS_RESTORE_AGE,
     CONF_OPTIONS_START_DELAY,
@@ -256,6 +257,7 @@ async def test_setup_with_auto_tenant_auto_apps_mqtt_fail(hass: HomeAssistant) -
             CONF_MQTT_USER: "user",
             CONF_MQTT_PWD: "pwd",
             CONF_MQTT_DISC: "ha",
+            CONF_MQTT_CHIRPSTACK_PREFIX: "",
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -293,6 +295,7 @@ async def test_setup_with_auto_tenant_auto_apps_mqtt(hass: HomeAssistant) -> Non
             CONF_MQTT_USER: "user",
             CONF_MQTT_PWD: "pwd",
             CONF_MQTT_DISC: "ha",
+            CONF_MQTT_CHIRPSTACK_PREFIX: "",
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
@@ -308,6 +311,7 @@ async def test_setup_with_auto_tenant_auto_apps_mqtt(hass: HomeAssistant) -> Non
         CONF_MQTT_USER: "user",
         CONF_MQTT_PWD: "pwd",
         CONF_MQTT_DISC: "ha",
+        CONF_MQTT_CHIRPSTACK_PREFIX: "",
     }
     assert result["options"] == {
         CONF_OPTIONS_START_DELAY: DEFAULT_OPTIONS_START_DELAY,
@@ -335,6 +339,7 @@ async def test_setup_with_duplicate(hass: HomeAssistant) -> None:
         CONF_MQTT_USER: "user",
         CONF_MQTT_PWD: "pwd",
         CONF_MQTT_DISC: "ha",
+        CONF_MQTT_CHIRPSTACK_PREFIX: "",
     }
     conf_options = {
         CONF_OPTIONS_START_DELAY: DEFAULT_OPTIONS_START_DELAY,
@@ -376,6 +381,7 @@ async def test_setup_with_duplicate(hass: HomeAssistant) -> None:
             CONF_MQTT_USER: "user",
             CONF_MQTT_PWD: "pwd",
             CONF_MQTT_DISC: "ha",
+            CONF_MQTT_CHIRPSTACK_PREFIX: "",
         },
     )
     assert result["type"] == data_entry_flow.FlowResultType.ABORT


### PR DESCRIPTION
- Small improvements for the README - my suggestion is to call the title "ChirpStack to HomeAssistant MQTT Integration" because ChirpStack provides the data to HA. Yes, HA subscripes to it, but the way is ChirpStack -> HA and first i was very confused by the title.

- I add support for ChirpStack MQTT prefixes (supported from ChripStack, but a little bit hidden in the `chirpstack.toml`:
```toml
[integration]
  enabled=["mqtt"]

  [integration.mqtt]
    server="tcp://$MQTT_HOST:1883/"
    username="$MQTT_USERNAME"
    password="$MQTT_PASSWORD"
    json=true
    event_topic="chirpstack/application/{{application_id}}/device/{{dev_eui}}/event/{{event}}"
    command_topic="chirpstack/application/{{application_id}}/device/{{dev_eui}}/command/{{command}}"
```